### PR TITLE
Rename metrics name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS Reserved Instance Normalized Unit Per Hour Exporter
+# AWS Reserved Instance Exporter
 
 ![test](https://github.com/44smkn/aws_ri_exporter/actions/workflows/test.yaml/badge.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -7,7 +7,7 @@ Metrics exporter for aws reserved instance normalized unit per hour.
 
 ## Installation and Usage
 
-The `aws_ri_exporter` listens on HTTP port 9981 by default. See the `--help` output for more options.
+The `aws_ri_exporter` listens on HTTP port **9981** by default. See the `--help` output for more options.
 
 You will need to have AWS API credentials configured. What works for AWS CLI, should be sufficient. You can use [~/.aws/credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) or [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set).
 
@@ -69,6 +69,7 @@ spec:
 Collectors are enabled by providing a `--collector.<name>` flag.
 Collectors that are enabled by default can be disabled by providing a `--no-collector.<name>` flag.
 
-| Collector | Description              | Mecrics                                                                                 |
-| ----------|------------------------- | --------------------------------------------------------------------------------------- |
-| `rds`     | Information about RDS RI | `ri_normalized_unit_rds_running_instance`<br>`ri_normalized_unit_rds_active_reservation`|
+| Collector | Metrics                                         | Description                                    |
+|-----------|-------------------------------------------------|------------------------------------------------|
+| rds       | `aws_ri_rds_running_instance_normalized_unit`   | Normalized Units for each running RDS instance |
+| rds       | `aws_ri_rds_active_reservation_normalized_unit` | Normalized Units for each active reservation   |

--- a/cmd/aws_ri_exporter/main.go
+++ b/cmd/aws_ri_exporter/main.go
@@ -74,7 +74,7 @@ func run(args []string) int {
 		w.Write([]byte(`<html>
 <head><title>AWS Reserved Instance Exporter</title></head>
 <body>
-<h1>AWS Reserved Instance Normalized Unit Per Hour Exporter</h1>
+<h1>AWS Reserved Instance Exporter</h1>
 <p><a href='` + *metricsPath + `'>Metrics</a></p>
 </body>
 </html>`))

--- a/pkg/collector/rds.go
+++ b/pkg/collector/rds.go
@@ -33,12 +33,12 @@ type rdsCollector struct {
 func NewRDSCollector(aws aws.Cloud, nuConverter nu.Converter, logger log.Logger) Collector {
 	c := &rdsCollector{
 		runningInstance: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, rdsCollectorSubsystem, "running_instance"),
+			prometheus.BuildFQName(namespace, rdsCollectorSubsystem, "running_instance_normalized_unit"),
 			"Normalized Units for each running RDS instance.",
 			[]string{"region", "instance_class", "engine", "instance_id"}, nil,
 		),
 		activeReservation: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, rdsCollectorSubsystem, "active_reservation"),
+			prometheus.BuildFQName(namespace, rdsCollectorSubsystem, "active_reservation_normalized_unit"),
 			"Normalized Units for each purchased reservation",
 			[]string{"region", "instance_class", "engine", "reservation_id"}, nil,
 		),


### PR DESCRIPTION
#### What type of PR is this?

feature

#### What this PR does / why we need it

I should change the metrics name when this product name was changed.
However, I forgot to change the metrics name.

#### Description of changes

I put the unit `normalized_unit` in the suffix of metrics.

#### Supported Information
